### PR TITLE
NER 모델 변경 후 문제점 : joon09/kor-naver-ner-name

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,8 +6,8 @@ import faiss
 import numpy as np
 from transformers import AutoTokenizer, AutoModelForTokenClassification, pipeline
 
-ner_tokenizer = AutoTokenizer.from_pretrained("Leo97/KoELECTRA-small-v3-modu-ner")
-ner_model     = AutoModelForTokenClassification.from_pretrained("Leo97/KoELECTRA-small-v3-modu-ner")
+ner_tokenizer = AutoTokenizer.from_pretrained("joon09/kor-naver-ner-name")
+ner_model     = AutoModelForTokenClassification.from_pretrained("joon09/kor-naver-ner-name")
 ner_pipeline  = pipeline(
     "ner",
     model=ner_model,


### PR DESCRIPTION
joon09/kor-naver-ner-name 모델로 교체하여 NER 결과 및 카테고리 분류 성능 비교 실험을 진행하였습니다.

변경 내용
- NER 모델: `joon09/kor-naver-ner-name` 적용
- 기타 로직은 기존과 동일

결과 요약
- 일부 개체명이 과도하게 치환되거나 의도하지 않은 토큰이 일반화되어 출력 결과가 다소 어색해졌습니다.
- 예시:
- Original: 민수랑 8시 술약속
Generalized: <PER><PER>랑 <TIM> 술약속

- 따라서 해당 모델은 기존 모델보다 실사용에 적합하지 않은 것으로 판단됩니다.