### PR TITLE
NER 모델 변경: yongsun-yoon/mdeberta-v3-base-open-ner

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,8 +6,8 @@ import faiss
 import numpy as np
 from transformers import AutoTokenizer, AutoModelForTokenClassification, pipeline
 
-ner_tokenizer = AutoTokenizer.from_pretrained("joon09/kor-naver-ner-name")
-ner_model     = AutoModelForTokenClassification.from_pretrained("joon09/kor-naver-ner-name")
+ner_tokenizer = AutoTokenizer.from_pretrained("yongsun-yoon/mdeberta-v3-base-open-ner")
+ner_model     = AutoModelForTokenClassification.from_pretrained("yongsun-yoon/mdeberta-v3-base-open-ner")
 ner_pipeline  = pipeline(
     "ner",
     model=ner_model,


### PR DESCRIPTION
yongsun-yoon/mdeberta-v3-base-open-ner 모델을 적용하여 성능 비교 실험을 진행했습니다.
- 일반화 결과가 전혀 적용되지 않아 텍스트가 원문 그대로 유지되었습니다

- 분류된 카테고리는 다음과 같습니다:
  - "엔진오일 교환" → 차량 관리
  - "민수랑 8시 술약속" → 연애
  - "오전 10시 주간회의" → 업무
  - "지윤이와 롯데몰 8시 데이트 약속" → 연애
  - "가족들과 저녁식사" → 가족
  - "민수랑 차량 정비" → 차량 관리

- 전반적으로 일반화 미적용으로 인해 의도한 NER 기반 분류 흐름과 어긋남
- 결론적으로 본 모델은 실험 결과에서 부적합 판정