### PR TITLE
NER 모델 변경: SungJoo/medical-ner-koelectra 비

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,8 +6,8 @@ import faiss
 import numpy as np
 from transformers import AutoTokenizer, AutoModelForTokenClassification, pipeline
 
-ner_tokenizer = AutoTokenizer.from_pretrained("yongsun-yoon/mdeberta-v3-base-open-ner")
-ner_model     = AutoModelForTokenClassification.from_pretrained("yongsun-yoon/mdeberta-v3-base-open-ner")
+ner_tokenizer = AutoTokenizer.from_pretrained("SungJoo/medical-ner-koelectra")
+ner_model     = AutoModelForTokenClassification.from_pretrained("SungJoo/medical-ner-koelectra")
 ner_pipeline  = pipeline(
     "ner",
     model=ner_model,


### PR DESCRIPTION
SungJoo/medical-ner-koelectra 모델로 NER 성능을 실험했습니다.
- 일반화된 텍스트가 거의 의미를 해석할 수 없는 형태로 처리되어 결과가 불안정하게 나왔습니다:

  예) Generalized: ['<B><I> <B>', '<I> <B><B> <B><I><B>', '<B> <B><I>', '<I><I> <B><I> <I><B> <B>', '<I><B> <I><B><I>', '<I> <B>']

- 이에 따른 카테고리 분류 결과는 다음과 같았습니다:
  
  - "엔진오일 교환" → 봉사
  - "민수랑 8시 술약속" → 재무
  - "오전 10시 주간회의" → 봉사
  - "지윤이와 롯데몰 8시 데이트 약속" → 재무
  - "가족들과 저녁식사" → 가사
  - "민수랑 차량 정비" → 봉사

- 대부분의 결과가 의미적으로 부정확하게 분류되었으며, 의도한 일반화 및 분류 흐름이 완전히 깨졌습니다.
- 결론적으로 해당 모델은 본 실험 목적에 적합하지 않았습니다.